### PR TITLE
Parse and fetch in parallel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v.0.3.0
+* Individual fetch and parse operations now run asynchronously
+
 ## v.0.2.2
 * Furlex now supports passing HTTP options to Furlex.unfurl/2.
 * `:depth` config has been transformed to a `:group_keys?` boolean.


### PR DESCRIPTION
Whereas fetch and parse operations have previously run (needlessly) synchronously, this PR converts them into asynchronous operations.