### PR TITLE
Feature/remove mix from production code

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -28,3 +28,7 @@ use Mix.Config
 # here (which is why it is important to import them last).
 #
 #     import_config "#{Mix.env}.exs"
+
+if :test = Mix.env() do
+  import_config("test.exs")
+end

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,5 @@
+use Mix.Config
+
+config :furlex, options: [
+  env: :test
+]

--- a/lib/furlex/oembed.ex
+++ b/lib/furlex/oembed.ex
@@ -93,10 +93,10 @@ defmodule Furlex.Oembed do
 
   @doc false
   def start_link(opts \\ []) do
-    GenServer.start_link(__MODULE__, opts)
+    GenServer.start_link(__MODULE__, Keyword.merge(opts, Application.get_env(:furlex, :options, [])))
   end
 
-  def init([env: :test]) do
+  def init(env: :test) do
     {:ok, [
       %{
         "provider_name" => "Vimeo",


### PR DESCRIPTION
Firstly just wanna say thanks for the package, saves a fair bit of work!

However, the use of `Mix.env` in the oembed module means that we're unable to use this in production currently, this PR removes the use of `Mix.env()` and adds an additional options key for `furlex`