### PR TITLE
Relaxes plug_cowboy dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -36,7 +36,7 @@ defmodule Furlex.Mixfile do
       {:floki, "~> 0.17.0"},
       {:httpoison, "~> 1.5"},
       {:jason, "~> 1.0", optional: true},
-      {:plug_cowboy, "~> 1.0"},
+      {:plug_cowboy, "~> 1.0 or ~> 2.0"},
 
       {:benchee, "~> 0.13", only: :dev},
       {:ex_doc, "~> 0.19", only: :dev, runtime: false},


### PR DESCRIPTION
Phoenix uses `cowboy` `~> 1.0 or ~> 2.0`, which makes overriding it necessary if you want to include furlex in a new Phoenix project. This relaxes the dependency to work with 1.0 or 2.0, as is the case with Phoenix.